### PR TITLE
Add tests for interaction between import() and microtask queue

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/microtasks.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/microtasks.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<title>Dynamic import interaction with microtask queue</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script type="module">
+
+function ticker(max) {
+  let i = 0;
+  let stop = false;
+  Promise.resolve().then(function loop() {
+    if (stop || i >= max) return;
+    i++;
+    Promise.resolve().then(loop);
+  });
+  return () => {
+    stop = true;
+    return i;
+  };
+}
+
+promise_test(async t => {
+  const getCount = ticker(1000);
+
+  try {
+    await import("<invalid>");
+    assert_unreached('import() should reject');
+  } catch (_) {}
+
+  assert_less_than(getCount(), 1000);
+}, "import() should not drain the microtask queue if it fails during specifier resolution");
+
+promise_test(async t => {
+  await import("./../imports-a.js");
+
+  const getCount = ticker(1000);
+  await import("./../imports-a.js");
+  assert_less_than(getCount(), 1000);
+}, "import() should not drain the microtask queue when loading an already loaded module");
+
+promise_test(async t => {
+  const getCount = ticker(1e7);
+  await import("./../imports-a.js?" + Date.now()); // Use Date.now() to ensure that the module is not in the module map
+  assert_equals(getCount(), 1e7);
+}, "import() should drain the microtask queue when fetching a new module");
+</script>


### PR DESCRIPTION
The HTML algorithms for dynamic import (starting from [HostImportModuleDynamically](https://html.spec.whatwg.org/#hostimportmoduledynamically(referencingscriptormodule,-modulerequest,-promisecapability))) only schedule a task a when actually fetching the corresponding files, and it never happens if the imported module (and all its dependencies) have already been loaded (when step 5 of [fetch a single module script](https://html.spec.whatwg.org/#fetch-a-single-module-script) doesn't happen and step 6 returns early).

However, browsers implement this inconsistently. This PR adds three new tests, and some of them fail:
| *Test* | *Firefox & Chrome* | *Safari* |
|:-|:-:|:-:|
| import() should not drain the microtask queue if it fails during specifier resolution | :heavy_check_mark: | :heavy_check_mark: |
| import() should not drain the microtask queue when loading an already loaded module | :x:  | :heavy_check_mark: |
| import() should drain the microtask queue when fetching a new module | :heavy_check_mark: | :heavy_check_mark: |

I didn't know how to test "it doesn't schedule a task", so the tests are written using a loop that schedules "many" microtasks and checking if all those microtasks are run or not before that the `import()` promise is resolved.